### PR TITLE
feat: add wslrelay.exe to patch

### DIFF
--- a/exe/main.cpp
+++ b/exe/main.cpp
@@ -31,7 +31,7 @@ bool listWslHosts(vector<DWORD>* pids)
 	}
 
 	do {
-		if (_wcsicmp(pe32.szExeFile, L"wslhost.exe") == 0) {
+		if (_wcsicmp(pe32.szExeFile, L"wslhost.exe") == 0) || (_wcsicmp(pe32.szExeFile, L"wslrelay.exe") == 0) {
 			pids->push_back(pe32.th32ProcessID);
 		}
 	} while (Process32Next(hProcessSnap, &pe32));


### PR DESCRIPTION
Add wslrelay.exe to patch list as newer version of wsl2 is using that instead of wslhost.exe to take care of port listening on windows side.

closes #18 